### PR TITLE
Simple one liner URL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Dependencies
 For generating cryptographically secure random numbers.
 
 **License:**
-https://github.com/paypal/seifrng/license.md
+https://github.com/paypal/seifrng/blob/master/LICENSE.md
 
 ### 2. [CryptoPP/Crypto++](https://www.cryptopp.com/)
 


### PR DESCRIPTION
**What does it do?**

It just fixes a link.

---

From this:
https://github.com/paypal/seifrng/license.md

To this:
https://github.com/paypal/seifrng/blob/master/LICENSE.md